### PR TITLE
Switched arg parsing from getopts to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,10 +2,20 @@
 name = "geofrac"
 version = "0.1.0"
 dependencies = [
+ "clap 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ansi_term"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -16,6 +26,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "byteorder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "color_quant"
@@ -68,11 +91,6 @@ dependencies = [
 [[package]]
 name = "gcc"
 version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "getopts"
-version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -245,5 +263,20 @@ dependencies = [
 [[package]]
 name = "rustc-serialize"
 version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["F"]
 [dependencies]
 colored = "1.2"
 image = "*"
-getopts = "0.2"
+clap = "2.5.1"

--- a/src/graphic.rs
+++ b/src/graphic.rs
@@ -11,205 +11,201 @@ use types::*;
 
 #[derive(Clone)]
 pub struct Config {
-	size: Float,
-	step: Float,
-	max_iters: Int,
-	escape_radius: Float,
-	with_color: bool,
-	filename: String,
-}
-
-impl Default for Config {
-	fn default() -> Self {
-		Config {
-			size: 2.0,
-			step: 0.01,
-			max_iters: 20,
-			escape_radius: 2.0,
-			with_color: false,
-			filename: "".to_string(),
-		}
-	}
-}
-
-pub struct GifConfig {
-	init_frame: Config,
-	zoom: Float,
-	z_step: Float,
-	z_centre_x: Float,
-	z_centre_y: Float,
-}
-
-impl Default for GifConfig {
-	fn default() -> Self {
-		GifConfig {
-			init_frame: Config::default(),
-			zoom: 2.0,
-			z_step: 1.0,
-			z_centre_x: -0.1011,
-			z_centre_y: 0.9563,
-		}
-	}
+    size: Float,
+    step: Float,
+    max_iters: Int,
+    escape_radius: Float,
+    with_color: bool,
+    filename: String,
 }
 
 impl Config {
-	pub fn size(mut self, size: Float) -> Self {
-		self.size = size;
-		self
-	}
+    pub fn new(size: Float, step: Float, iters: Int, radius: Float) -> Self {
+        Config {
+            size: size,
+            step: step,
+            max_iters: iters,
+            escape_radius: radius,
 
-	pub fn step(mut self, step: Float) -> Self {
-		self.step = step;
-		self
-	}
+            // TODO: Make modifiable
+            with_color: true,
+            filename: "".to_string(),
+        } 
+    }
+    
+    pub fn size(mut self, size: Float) -> Self {
+	self.size = size;
+	self
+    }
 
-	pub fn max_iters(mut self, iters: Int) -> Self {
-		self.max_iters = iters;
-		self
-	}
+    pub fn step(mut self, step: Float) -> Self {
+	self.step = step;
+	self
+    }
 
-	pub fn escape_radius(mut self, radius: Float) -> Self {
-		self.escape_radius = radius;
-		self
-	}
+    pub fn max_iters(mut self, iters: Int) -> Self {
+	self.max_iters = iters;
+	self
+    }
 
-	pub fn with_color(mut self, col: bool) -> Self {
-		self.with_color = col;
-		self
-	}
+    pub fn escape_radius(mut self, radius: Float) -> Self {
+	self.escape_radius = radius;
+	self
+    }
 
-	pub fn filename(mut self, filename : Option<String>) -> Self {
-		self.filename = match filename {
-				Some(f) => f,
-				_		=> "".to_string(),
-		};
-		self
-	}
+    pub fn greyscale(mut self) -> Self {
+	self.with_color = false;
+	self
+    }
 
-	pub fn gen_loop(&self) {
-		let img_dim : Img = ((self.size * 2.0) / self.step) as Img;
-		let mut buffer = image::ImageBuffer::new(img_dim, img_dim);
+    pub fn filename(mut self, filename : String) -> Self {
+        self.filename = filename;
+	self
+    }
 
-		//Coordinate variable initialisation
-		let mut x : Float;
-		let mut y : Float = self.size;
+    pub fn run(&self) {
+	let img_dim : Img = ((self.size * 2.0) / self.step) as Img;
+	let mut buffer = image::ImageBuffer::new(img_dim, img_dim);
 
-		//Channel creation for threads to pass back colours
-		let (tx, rx) = mpsc::channel();
-		//Greyscale colouring scaler
-		let scl : Float = 255.0/(self.max_iters as Float);
-		//Values for threads to reduce copying
-		let mx = self.max_iters;
-		let er = self.escape_radius;
-		
-		//Y pixel count
-		for y_cnt in (0..(img_dim-1)).rev() {
-			//x coordinate
-			x = -1.0 * self.size;
+	//Coordinate variable initialisation
+	let mut x : Float;
+	let mut y : Float = self.size;
 
-			//X pixel count
-			for x_cnt in 0..(img_dim-1) {
-				//Clone sender for channel
-				let tx = tx.clone();
-				//If not coloured
-				if !self.with_color {
-					//Creates greyscale thread
-					thread::spawn(move || {
-						let xy_steps : Int = fracmaths::get_passes_mandelbrot((x, y), mx, er);
-						//Calculate colour value for
-						tx.send((x_cnt,y_cnt,((scl*(xy_steps as Float)) as u8),None,None)).unwrap();
-					});
-				} else {
-					thread::spawn(move || {
-						let xy_steps : Int = fracmaths::get_passes_mandelbrot((x, y), mx, er);
-						let mut rgb = (0,0,0);
-						if xy_steps != mx {
-							rgb = (rgb_val(xy_steps, 0),rgb_val(xy_steps, 1), rgb_val(xy_steps, 2));
-						}
-						tx.send((x_cnt,y_cnt,rgb.0,Some(rgb.1),Some(rgb.2))).unwrap();
-					});
-				}
-				x += self.step;
+	//Channel creation for threads to pass back colours
+	let (tx, rx) = mpsc::channel();
+	//Greyscale colouring scaler
+	let scl : Float = 255.0/(self.max_iters as Float);
+	//Values for threads to reduce copying
+	let mx = self.max_iters;
+	let er = self.escape_radius;
+	
+	//Y pixel count
+	for y_cnt in (0..(img_dim-1)).rev() {
+	    //x coordinate
+	    x = -1.0 * self.size;
+
+	    //X pixel count
+	    for x_cnt in 0..(img_dim-1) {
+		//Clone sender for channel
+		let tx = tx.clone();
+		//If not coloured
+		if !self.with_color {
+		    //Creates greyscale thread
+		    thread::spawn(move || {
+			let xy_steps : Int = fracmaths::get_passes_mandelbrot((x, y), mx, er);
+			//Calculate colour value for
+			tx.send((x_cnt,y_cnt,((scl*(xy_steps as Float)) as u8),None,None)).unwrap();
+		    });
+		} else {
+		    thread::spawn(move || {
+			let xy_steps : Int = fracmaths::get_passes_mandelbrot((x, y), mx, er);
+			let mut rgb = (0,0,0);
+			if xy_steps != mx {
+			    rgb = (rgb_val(xy_steps, 0),rgb_val(xy_steps, 1), rgb_val(xy_steps, 2));
 			}
-			y -= self.step;
+			tx.send((x_cnt,y_cnt,rgb.0,Some(rgb.1),Some(rgb.2))).unwrap();
+		    });
 		}
-
-		for _ in (0..(img_dim-1)).rev() {
-			for _ in 0..(img_dim-1) {
-				let (p,q,r,maybeg,maybeb) = rx.recv().unwrap();
-				match maybeg {
-					Some(g) if maybeb.is_some() =>
-							buffer.put_pixel(p, q, image::Rgb([r,g,maybeb.unwrap()])),
-					_	=> {
-								buffer.put_pixel(p, q, image::Rgb([r,r,r]));
-							}
-				}
-			}
-		}
-
-		let b = match self.with_color{
-				true => "",
-				false=> "-bw",
-		};
-
-		let mut filename = &format!("./res/fractal-St{}-Mx{}{}.png", self.step, self.max_iters,b);
-		if self.filename != "" {
-			filename = &self.filename;
-		}
-		
-		let file = &mut File::create(&Path::new(filename)).unwrap();
-		let _ = image::ImageRgb8(buffer).save(file, image::PNG);
+		x += self.step;
+	    }
+	    y -= self.step;
 	}
+
+	for _ in (0..(img_dim-1)).rev() {
+	    for _ in 0..(img_dim-1) {
+		let (p,q,r,maybeg,maybeb) = rx.recv().unwrap();
+		match maybeg {
+		    Some(g) if maybeb.is_some() =>
+			buffer.put_pixel(p, q, image::Rgb([r,g,maybeb.unwrap()])),
+		    _	=> {
+			buffer.put_pixel(p, q, image::Rgb([r,r,r]));
+		    }
+		}
+	    }
+	}
+
+	let b = match self.with_color{
+	    true => "",
+	    false=> "-bw",
+	};
+
+	let mut filename = &format!("./res/fractal-St{}-Mx{}{}.png", self.step, self.max_iters,b);
+	if self.filename != "" {
+	    filename = &self.filename;
+	}
+	
+	let file = &mut File::create(&Path::new(filename)).unwrap();
+	let _ = image::ImageRgb8(buffer).save(file, image::PNG);
+    }
 
 
 }
 fn rgb_val(steps : Int, scl : Int) -> u8 {
-	((-255.0*
-		((steps as Float)*(20.0*(scl as Float)/(f32::consts::PI))).cos()) as Float
-		+255.0) as u8
+    ((-255.0*
+      ((steps as Float)*(20.0*(scl as Float)/(f32::consts::PI))).cos()) as Float
+     +255.0) as u8
+}
+
+pub struct GifConfig {
+    init_frame: Config,
+    zoom: Float,
+    z_step: Float,
+    z_centre_x: Float,
+    z_centre_y: Float,
 }
 
 impl GifConfig {
-	pub fn init_frame(mut self, init: Config) -> Self {
-		self.init_frame = init;
-		self
+    pub fn new(generator: Config, zoom: Float, z_step: Float, x: Float, y: Float) -> Self {
+        GifConfig {
+            init_frame: generator,
+            zoom: zoom,
+            z_step: z_step,
+            z_centre_x: x,
+            z_centre_y: y,
+        }
+    }
+    
+    pub fn init_frame(mut self, init: Config) -> Self {
+	self.init_frame = init;
+	self
+    }
+
+    pub fn zoom(mut self, zoom: Float) -> Self {
+	self.zoom = zoom;
+	self
+    }
+
+    pub fn z_step(mut self, step: Float) -> Self {
+	self.z_step = step;
+	self
+    }
+
+    pub fn z_centre_x(mut self, centre: Float) -> Self {
+	self.z_centre_x = centre;
+	self
+    }
+
+    pub fn z_centre_y(mut self, centre: Float) -> Self {
+	self.z_centre_y = centre;
+	self
+    }
+
+
+    pub fn run(&mut self){
+        println!("generating...");
+	let mut curr_z : Float = 1.0;
+	let mut count = 0;
+	loop{
+	    count+=1;
+	    self.init_frame.filename = format!("./gif/{}.png",count);
+	    self.init_frame.size = (1.0/curr_z)*self.init_frame.size;
+	    self.init_frame.step = (1.0/curr_z)*self.init_frame.step;
+	    self.init_frame.run();
+	    curr_z += self.z_step;
+	    if curr_z > self.zoom {
+		break;
+	    }
 	}
 
-	pub fn zoom(mut self, zoom: Float) -> Self {
-		self.zoom = zoom;
-		self
-	}
-
-	pub fn z_step(mut self, step: Float) -> Self {
-		self.z_step = step;
-		self
-	}
-
-	pub fn z_centre_x(mut self, centre: Float) -> Self {
-		self.z_centre_x = centre;
-		self
-	}
-
-	pub fn z_centre_y(mut self, centre: Float) -> Self {
-		self.z_centre_y = centre;
-		self
-	}
-
-
-	pub fn gif_loop(&mut self){
-		let mut curr_z : Float = 1.0;
-		let mut count = 0;
-		loop{
-			count+=1;
-			self.init_frame.filename= format!("./gif/{}.png",count);
-			self.init_frame.size 	= (1.0/curr_z)*self.init_frame.size;
-			self.init_frame.step 	= (1.0/curr_z)*self.init_frame.step;
-			self.init_frame.gen_loop();
-			curr_z += self.z_step;
-			if curr_z > self.zoom {
-				break;
-			}
-		}
-
-	}
+    }
 }


### PR DESCRIPTION
Provides cleaner interface.

GIF and Still image outputs are produced via subcommands.

```
./target/debug/geofrac still 2.0 0.01 20 2.0
```

```
./target/debug/geofrac gif 2.0 0.01 20 2.0 2.0 1.0 -- -0.1011 0.9563
```

Note: the -- disables option parsing and allows negative arguments
